### PR TITLE
stop mic button issue is fixed

### DIFF
--- a/udan-react-ts/src/components/MicButton.tsx
+++ b/udan-react-ts/src/components/MicButton.tsx
@@ -52,6 +52,7 @@ const MicButton = ({ onSpeech, selectedLang }: IMicButtonProps) => {
 
   const stopRecord = () => {
     recognition.current.stop();
+    setIsRecording(false);
   };
 
   return (


### PR DESCRIPTION
1. While recording the speech, if we want to stop the recording by clicking on the stop mic button, earlier the button was not responding. Now this issue is fixed. We can stop the recording.